### PR TITLE
Centralize rockauth provider configurations.

### DIFF
--- a/lib/generators/templates/rockauth_full_initializer.rb
+++ b/lib/generators/templates/rockauth_full_initializer.rb
@@ -8,15 +8,13 @@ Rockauth.configure do |config|
   # config.jwt.issuer = ''
   # config.jwt.signing_method = 'HS256'
 
-  config.jwt.secret              = "<%= SecureRandom.base64(32) %>"
+  config.jwt.secret              = '<%= SecureRandom.base64(32) %>'
   config.resource_owner_class    = '::User'
-  config.twitter.consumer_key    = ENV['TWITTER_CONSUMER_KEY']
-  config.twitter.consumer_secret = ENV['TWITTER_CONSUMER_SECRET']
 
-  config.serializers.user                    = "::UserSerializer"
-  config.serializers.authentication          = "::AuthenticationSerializer"
-  config.serializers.provider_authentication = "::ProviderAuthenticationSerializer"
-  config.serializers.error                   = "::ErrorSerializer"
+  config.serializers.user                    = '::UserSerializer'
+  config.serializers.authentication          = '::AuthenticationSerializer'
+  config.serializers.provider_authentication = '::ProviderAuthenticationSerializer'
+  config.serializers.error                   = '::ErrorSerializer'
 
   # config.generate_active_admin_resources = nil # nil decides based on whether active_admin is loaded
   # config.active_admin_menu_name = 'User Authentication'
@@ -29,11 +27,16 @@ Rockauth.configure do |config|
     warn 'Could not load Rockauth clients from config/rockauth_clients.yml'
   end
 
-end
+  begin
+    config.providers = OpenStruct.new(JSON.parse(File.read(Rails.root.join('config/rockauth_providers.json'))[Rails.env]))
+  rescue Errno::ENOENT
+    warn 'Could not load Rockauth providers from config/rockauth_providers.json'
+  end
 
-Instagram.configure do |config|
-  config.client_id     = ENV['INSTAGRAM_CLIENT_ID']
-  config.client_secret = ENV['INSTAGRM_CLIENT_SECRET']
-end
+  Instagram.configure do |instagram_config|
+    instagram_config.client_id     = config.providers.instagram[:client_id]
+    instagram_config.client_secret = config.providers.instagram[:client_secret]
+  end
 
-GooglePlus.api_key = ENV['GOOGLE_PLUS_API_KEY']
+  GooglePlus.api_key = config.providers.google_plus[:api_key]
+end

--- a/lib/generators/templates/rockauth_providers.json
+++ b/lib/generators/templates/rockauth_providers.json
@@ -1,0 +1,67 @@
+{
+  "test": {
+    "twitter": {
+      "consumer_key": "",
+      "consumer_secret": ""
+    },
+    "instagram": {
+      "client_id": "",
+      "client_secret": ""
+    },
+    "google_plus": {
+      "api_key": ""
+    }
+  },
+  "development": {
+    "twitter": {
+      "consumer_key": "",
+      "consumer_secret": ""
+    },
+    "instagram": {
+      "client_id": "",
+      "client_secret": ""
+    },
+    "google_plus": {
+      "api_key": ""
+    }
+  },
+  "qa": {
+    "twitter": {
+      "consumer_key": "",
+      "consumer_secret": ""
+    },
+    "instagram": {
+      "client_id": "",
+      "client_secret": ""
+    },
+    "google_plus": {
+      "api_key": ""
+    }
+  },
+  "staging": {
+    "twitter": {
+      "consumer_key": "",
+      "consumer_secret": ""
+    },
+    "instagram": {
+      "client_id": "",
+      "client_secret": ""
+    },
+    "google_plus": {
+      "api_key": ""
+    }
+  },
+  "production": {
+    "twitter": {
+      "consumer_key": "",
+      "consumer_secret": ""
+    },
+    "instagram": {
+      "client_id": "",
+      "client_secret": ""
+    },
+    "google_plus": {
+      "api_key": ""
+    }
+  }
+}

--- a/lib/rockauth/configuration.rb
+++ b/lib/rockauth/configuration.rb
@@ -1,6 +1,6 @@
 module Rockauth
   Configuration = Struct.new(*%i(allowed_password_length email_regexp token_time_to_live clients
-                                 resource_owner_class warn_missing_social_auth_gems twitter jwt
+                                 resource_owner_class warn_missing_social_auth_gems providers jwt
                                  serializers generate_active_admin_resources active_admin_menu_name)) do
     def resource_owner_class= arg
       @constantized_resource_owner_class = nil
@@ -16,7 +16,6 @@ module Rockauth
     config.clients = []
     config.resource_owner_class = 'Rockauth::User'
     config.warn_missing_social_auth_gems = true
-    config.twitter = Struct.new(:consumer_key, :consumer_secret).new
 
     config.jwt = Struct.new(*%i(secret issuer signing_method)).new.tap do |jwt_config|
       jwt_config.secret = ''

--- a/lib/rockauth/provider_user_information.rb
+++ b/lib/rockauth/provider_user_information.rb
@@ -52,8 +52,8 @@ module Rockauth
 
       def twitter_client
         @twitter_client ||= ::Twitter::REST::Client.new do |config|
-          config.consumer_key        = Configuration.twitter[:consumer_key]
-          config.consumer_secret     = Configuration.twitter[:consumer_secret]
+          config.consumer_key        = Configuration.providers.twitter[:consumer_key]
+          config.consumer_secret     = Configuration.providers.twitter[:consumer_secret]
           config.access_token        = access_token
           config.access_token_secret = access_token_secret
         end


### PR DESCRIPTION
This moves provider credentials optionally away from environment variables. This can be achieved by providing a JSON document that contains the providers separated by environment. Which this will be the default behavior for the time being.