### PR TITLE
Dependent nullify for provider_authentication authentications

### DIFF
--- a/app/models/rockauth/provider_authentication.rb
+++ b/app/models/rockauth/provider_authentication.rb
@@ -4,6 +4,7 @@ module Rockauth
   class ProviderAuthentication < ActiveRecord::Base
     self.table_name = 'provider_authentications'
     belongs_to :resource_owner, polymorphic: true, inverse_of: :provider_authentications
+    has_many :authentications, class_name: 'Rockauth::Authentication', dependent: :nullify
 
     include Models::ProviderValidation
 

--- a/spec/controllers/rockauth/provider_authentications_controller_spec.rb
+++ b/spec/controllers/rockauth/provider_authentications_controller_spec.rb
@@ -133,6 +133,7 @@ module Rockauth
       context "when authenticated", authenticated_request: true do
         let!(:provider_authentication) { create(:provider_authentication, resource_owner: given_auth.resource_owner) }
         it "delete the provider authentication" do
+          create(:authentication, resource_owner: given_auth.resource_owner, provider_authentication: provider_authentication)
           expect {
             delete :destroy, id: provider_authentication.id, provider_authentication: { provider_access_token: 'blarg' }
           }.to change { given_auth.resource_owner.provider_authentications.where(id: provider_authentication.id).count }.from(1).to(0)


### PR DESCRIPTION
Fix an issue with authentications not being able to be deleted. By nullifying the provider_authentication field on deletion.